### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Build go-neb
 FROM golang:1.16-alpine as builder
 
-RUN apk add --no-cache -t build-deps git gcc musl-dev go make g++
+RUN apk add --no-cache -t build-deps git gcc musl-dev go make cmake g++
 
 RUN git clone https://gitlab.matrix.org/matrix-org/olm.git /tmp/libolm \
     && cd /tmp/libolm \
-    && make install
+    && cmake . -Bbuild \
+    && cmake --build build --target install
 
 COPY . /tmp/go-neb
 WORKDIR /tmp/go-neb


### PR DESCRIPTION
Olm does not include `olm_export.h` when installed with make. This results in a build error when building the Dockerfile.  
Building the project with cmake is preferred anyway as stated in the [README](https://gitlab.matrix.org/matrix-org/olm/-/blob/master/README.md) of the olm project.